### PR TITLE
Add Video Boost AO

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ Pull requests are welcome. See [Contributing](CONTRIBUTING.md) for hints. Closed
 * [Root-My-Pixel](https://github.com/alex193a/Root-My-Pixel) - Root automation for Pixel devices via CVE-2026-43499 exploit `Proprietary`
 * [Smartspacer](https://github.com/KieronQuinn/Smartspacer) - Customizable widget, can upgrade the built-in 'At a glance' widget on Pixel devices using Shizuku `GPL-3.0`
 * [TurboIMS](https://github.com/Turbo1123/TurboIMS) - Enhanced IMS Configuration Tool for Google Pixel devices `Apache-2.0`
+* [Video Boost AO](https://github.com/AgusRomeroL/video-boost-ao) - Keeps Video Boost enabled on Pixel Pro cameras, re-enabling it every time the camera opens. Shizuku grants WRITE_SECURE_SETTINGS for the on-demand mode `MIT`
 
 #### Samsung OneUI
 


### PR DESCRIPTION
Adds **Video Boost AO** to the Google Pixel section, inserted in alphabetical order after TurboIMS.

Pixel Camera turns Video Boost off every time the app is closed, and there is no flag or preference that pins it without root. The app re-enables it automatically on every camera session.

Shizuku's role: the optional on-demand mode keeps the accessibility service switched off unless Pixel Camera is in the foreground, which needs `WRITE_SECURE_SETTINGS`. Shizuku is one of the two ways to grant it, alongside a built-in wireless ADB path. The default mode works without Shizuku.

Against the listing requirements:

- English readme and documentation.
- Not deprecated, actively maintained, latest release v2.13 published this week.
- Download link available: signed APK attached to every GitHub release.
- Open source under `MIT`, so it belongs in the main list.
- Description is 151 characters, under the 250 limit. No separate source code link, since the main link is the source.