### PR TITLE
Add Dexor to Software management

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Pull requests are welcome. See [Contributing](CONTRIBUTING.md) for hints. Closed
 * [Buge App Manager](https://github.com/BugeStudioTeam/Buge-App-Manager) - An app manager focusing on permission management `GPL-3.0`
 * [Canta](https://play.google.com/store/apps/details?id=io.github.samolego.canta) - Uninstall any app without root `LGPL-3.0` [(Source code)](https://github.com/samolego/Canta)
 * [CloneCat](https://github.com/AhmetCanArslan/CloneCat) - Clone and manage apps across work profile, private space, dual apps, and secondary users with home screen shortcuts `Proprietary`
+* [Dexor](https://github.com/DeveshTone/Dexor) - Ahead-of-time (AOT) bytecode compilation and dexopt runtime manager for Android applications `MIT`
 * [DisabledLauncher](https://github.com/voruti/DisabledLauncher) - Android app that disables unused apps while still allowing convenient access to them `MIT`
 * [FreezeYou](https://f-droid.org/packages/cf.playhi.freezeyou/) - Improve your device's speed and battery life by freezing crappy software manually or semi-automatically `Apache-2.0` [(Source code)](https://github.com/FreezeYou/FreezeYou)
 * [Hail](https://f-droid.org/packages/com.aistra.hail/) ✨ - Freeze, hide, or disable any app. Create and organize app groups that can be frozen with one click. `GPL-3.0` [(Source code)](https://github.com/aistra0528/Hail)


### PR DESCRIPTION
### Summary

Adds **[Dexor](https://github.com/DeveshTone/Dexor)** to the `Software management` section in alphabetical order.

### Project Details
- **Project:** [Dexor](https://github.com/DeveshTone/Dexor)
- **Description:** Ahead-of-time (AOT) bytecode compilation and dexopt runtime manager for Android applications (92 characters, under limit)
- **License:** MIT (`MIT`)
- **Category:** `Software management` (inserted alphabetically between `CloneCat` and `DisabledLauncher`)
- **Tags:** None required (100% free, no ads, no in-app purchases, no trial, non-root)
- **Download:** APK binary available on [GitHub Releases](https://github.com/DeveshTone/Dexor/releases)

Complies with all guidelines defined in [`CONTRIBUTING.md`](CONTRIBUTING.md).
